### PR TITLE
Force read only mode

### DIFF
--- a/news/2.bugfix
+++ b/news/2.bugfix
@@ -1,0 +1,1 @@
+Open Data.fs in read only mode.

--- a/src/zodbverify/__main__.py
+++ b/src/zodbverify/__main__.py
@@ -30,7 +30,7 @@ def main(argv=sys.argv):
     options = parser.parse_args(argv[1:])
 
     logging.basicConfig(level=logging.INFO)
-    storage = FileStorage(options.zodbfile)
+    storage = FileStorage(options.zodbfile, read_only=True)
     verify_zodb(storage, debug=options.debug)
 
 


### PR DESCRIPTION
This also allows to open a ZODB file which is currently used by another process as it does not require to lock it.

Fixes #2