### PR TITLE
Get more information about oids that create errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,12 +45,35 @@ The verification runs in the context of the initialized Zope application.
 Usage::
 
     ./bin/instance zodbverify [-h] [-D]
-
     Verifies that all records in the database can be loaded.
 
     optional arguments:
       -h, --help   show this help message and exit
       -D, --debug  pause to debug broken pickles
+
+
+Inspecting a single oid
+-----------------------
+
+The output of zodbverify gives you a list of all problems and the oid that are affected.
+
+To inspect a single oid in detail you can pass one of these to zodbverify::
+
+  ./bin/instance zodbverify -o 0x2e929f
+
+This will output the pickle and the errot for that oid.
+
+By also adding the debug-switch you will get two pdb's while the script runs::
+
+  ./bin/instance zodbverify -o 0x2e929f -D
+
+  2020-03-11 10:40:24,972 INFO    [Zope:45][MainThread] Ready to handle requests
+  The object is 'obj'
+  The Zope instance is 'app'
+  [4] > /Users/pbauer/workspace/dipf-intranet/src-mrd/zodbverify/src/zodbverify/verify_oid.py(52)verify_oid()
+  -> pickle, state = storage.load(oid)
+
+In the first pdb you have the object for the oid as `obj` and the zope instance as `app`. Before the second pdb the pickle will be disassembled the same way as when using zodbverify to pause to debug broken pickles without passing a oid.
 
 
 Source Code

--- a/README.rst
+++ b/README.rst
@@ -27,14 +27,16 @@ Run i.e.::
 
 Usage::
 
-    zodbverify [-h] -f ZODBFILE [-D]
+    zodbverify [-h] -f ZODBFILE [-D] [-o OID]
 
     Verifies that all records in the database can be loaded.
 
     optional arguments:
       -h, --help            show this help message and exit
       -f ZODBFILE, --zodbfile ZODBFILE
+                            Path to file-storage
       -D, --debug           pause to debug broken pickles
+      -o OID, --oid OID     oid to inspect
 
 
 plone.recipe.zope2instance integration
@@ -44,12 +46,14 @@ The verification runs in the context of the initialized Zope application.
 
 Usage::
 
-    ./bin/instance zodbverify [-h] [-D]
+    ./bin/instance zodbverify [-h] [-D] [-o OID]
+
     Verifies that all records in the database can be loaded.
 
     optional arguments:
-      -h, --help   show this help message and exit
-      -D, --debug  pause to debug broken pickles
+      -h, --help         show this help message and exit
+      -D, --debug        pause to debug broken pickles
+      -o OID, --oid OID  oid to inspect
 
 
 Inspecting a single oid

--- a/src/zodbverify/__main__.py
+++ b/src/zodbverify/__main__.py
@@ -5,6 +5,7 @@ import sys
 from ZODB.FileStorage import FileStorage
 
 from .verify import verify_zodb
+from .verify_oid import verify_oid
 
 
 def main(argv=sys.argv):
@@ -27,11 +28,21 @@ def main(argv=sys.argv):
         dest="debug",
         help="pause to debug broken pickles",
     )
+    parser.add_argument(
+        "-o",
+        "--oid",
+        action="store",
+        dest="oid",
+        help="oid to inspect",
+    )
     options = parser.parse_args(argv[1:])
 
     logging.basicConfig(level=logging.INFO)
     storage = FileStorage(options.zodbfile, read_only=True)
-    verify_zodb(storage, debug=options.debug)
+    if options.oid:
+        verify_oid(storage, options.oid, debug=options.debug)
+    else:
+        verify_zodb(storage, debug=options.debug)
 
 
 if __name__ == "__main__":

--- a/src/zodbverify/entrypoint.py
+++ b/src/zodbverify/entrypoint.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from zodbverify.verify import verify_zodb
+from zodbverify.verify_oid import verify_oid
 from Zope2.Startup.run import make_wsgi_app
 
 import argparse
@@ -18,6 +19,13 @@ parser.add_argument(
     dest="debug",
     help="pause to debug broken pickles",
 )
+parser.add_argument(
+    "-o",
+    "--oid",
+    action="store",
+    dest="oid",
+    help="oid to inspect",
+)
 
 
 def zopectl_entry(self, arg):
@@ -26,4 +34,8 @@ def zopectl_entry(self, arg):
     logging.basicConfig(level=logging.INFO)
     make_wsgi_app({}, self.options.configfile)
     app = Zope2.app()
-    verify_zodb(app._p_jar._db._storage, debug=options.debug)
+    storage = app._p_jar._db._storage
+    if options.oid:
+        verify_oid(storage, options.oid, debug=options.debug, app=app)
+    else:
+        verify_zodb(storage, debug=options.debug)

--- a/src/zodbverify/verify_oid.py
+++ b/src/zodbverify/verify_oid.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from ZODB.interfaces import IStorageCurrentRecordIteration
+from ZODB.utils import oid_repr
+from ZODB.utils import p64
+from zodbverify.verify import verify_record
+
+import logging
+import pdb
+import traceback
+import ZODB
+
+
+logger = logging.getLogger("zodbverify")
+
+
+def verify_oid(storage, oid, debug=False, app=None):
+    if not IStorageCurrentRecordIteration.providedBy(storage):
+        raise TypeError(
+            "ZODB storage {} does not implement record_iternext".format(storage)
+        )
+
+    if not isinstance(oid, bytes):
+        oid = p64(int(oid, 0))
+
+    if app:
+        # use exitsing zope instance.
+        # only available when used as ./bin/instance zodbverify -o XXX
+        connection = app._p_jar
+    else:
+        # connect to database to be able to load the object
+        db = ZODB.DB(storage)
+        connection = db.open()
+
+    try:
+        obj = connection.get(oid)
+        try:
+            logger.info("\nObject as dict:\n{}".format(vars(obj)))
+        except TypeError:
+            pass
+        if debug:
+            hint = "\nThe object is 'obj'"
+            if app:
+                hint += "\nThe Zope instance is 'app'"
+            logger.info(hint)
+            pdb.set_trace()
+    except Exception as e:
+        logger.info("Could not load object")
+        logger.info(traceback.format_exc())
+        if debug:
+            pdb.set_trace()
+
+    pickle, state = storage.load(oid)
+
+    success, msg = verify_record(oid, pickle, debug)
+    if not success:
+        logger.info('{}: {}'.format(msg, oid_repr(oid)))


### PR DESCRIPTION
1. List all oids for a specific error
2. New feature: inspect a single oid by passing it to zodbverify. The idea is to run zodbverify on the whole database and from the output copy one oid and run it again to further inspect that object.

