### PR TITLE
show all objects that reference a oid

### DIFF
--- a/src/zodbverify/verify_oid.py
+++ b/src/zodbverify/verify_oid.py
@@ -4,10 +4,14 @@ from ZODB.interfaces import IStorageCurrentRecordIteration
 from ZODB.serialize import get_refs
 from ZODB.utils import get_pickle_metadata
 from ZODB.utils import oid_repr
+from ZODB.utils import repr_to_oid
 from ZODB.utils import p64
+from ZODB.utils import tid_repr
 from zodbverify.verify import verify_record
 
+import json
 import logging
+import os
 import pdb
 import traceback
 import ZODB
@@ -18,17 +22,24 @@ logger = logging.getLogger("zodbverify")
 
 class Refbuilder(object):
 
-    def __init__(self, storage):
+    def __init__(self, storage, connection):
         self.storage = storage
+        self.connection = connection
         self.seen = []
         self.refs = defaultdict(list)
+        self.msg = []
         self.stop_recurse = [
-            p64(0x00),  # persistent.mapping.PersistentMapping
-            p64(0x01),  # OFS.Application.Application
-            p64(0x11),  # Products.CMFPlone.Portal.PloneSite
+            '0x00',  # persistent.mapping.PersistentMapping
+            '0x01',  # OFS.Application.Application
+            '0x11',  # Products.CMFPlone.Portal.PloneSite
         ]
 
-    def build_ref_tree(self):
+    def get_oid_report(self, oid, level=0, max_level=600, verbose=False):
+        self.msg.append('The oid {} is referenced by:\n'.format(oid))
+        self.inspect_reference_tree(oid, level=0, max_level=600, verbose=verbose)
+        logger.info('\n'.join(self.msg))
+
+    def _build_ref_tree(self):
         logger.info('Building a reference-tree of ZODB...')
         count = 0
         next_ = None
@@ -39,33 +50,141 @@ class Refbuilder(object):
             # For each oid create a list of oids that reference it
             # Can be used for reverse lookup similar to what fsoids.py
             # in ZODB does.
-            # We store integers since that uses less memory.
             oid_refs = get_refs(data)
             if oid_refs:
                 for referenced_oid, class_info in oid_refs:
-                    self.refs[referenced_oid].append(oid)
+                    self.refs[oid_repr(referenced_oid)].append(oid_repr(oid))
             if next_ is None:
                 break
-            if not count % 5000:
+            if not count % 10000:
                 logger.info('Objects: {}'.format(count))
         logger.info('Created a reference-dict for {} objects.\n'.format(count))
 
-    def get_refs(self, oid, level=0, max_level=10):
+    def inspect_reference_tree(self, oid, level=0, max_level=600, verbose=False):
+        if oid not in self.refs:
+            logger.debug('The oid {} does not exist!'.format(oid))
+            return
+        child_pickle, state = self.storage.load(repr_to_oid(oid))
+        child_class_info = '%s.%s' % get_pickle_metadata(child_pickle)
+
         for ref in self.refs[oid]:
             if ref in self.seen:
                 continue
             level += 1
             if level > max_level:
-                logger.info(' 8< --------------- >8 Stop after level {}!\n'.format(max_level))
+                msg = '8< --------------- >8 Stop after level {}!\n'.format(max_level)
+                self.msg.append(msg)
+                logger.debug(msg)
                 continue
             self.seen.append(ref)
-            pick, state = self.storage.load(ref)
+            pick, state = self.storage.load(repr_to_oid(ref))
             class_info = '%s.%s' % get_pickle_metadata(pick)
-            logger.info('{} {} at level {}'.format(oid_repr(ref), class_info, level))
+            name = None
+            if verbose:
+                name = self.get_id_or_attr_name(oid=oid, parent_oid=ref)
+
+            if name:
+                msg = '{} ({}) is {} for {} ({}) at level {}'.format(oid, child_class_info, name, ref, class_info, level)
+            else:
+                msg = '{} ({}) is referenced by {} ({}) at level {}'.format(oid, child_class_info, ref, class_info, level)
+            self.msg.append(msg)
+            logger.debug(msg)
+
             if oid in self.stop_recurse:
-                logger.info(' 8< --------------- >8 Stop at root objects\n')
+                msg = '8< --------------- >8 Stop at root objects'
+                self.msg.append(msg)
+                logger.debug(msg)
                 continue
-            self.get_refs(ref, level)
+            self.inspect_reference_tree(ref, level=level, verbose=verbose)
+
+    @property
+    def root_oid(self):
+        return self.connection.root._root._p_oid
+
+    def oid_or_repr_to_oid(self, oid_or_repr):
+        if isinstance(oid_or_repr, bytes):
+            return oid_or_repr
+        return repr_to_oid(oid_or_repr)
+
+    def oid_or_repr_to_repr(self, oid_or_repr):
+        if isinstance(oid_or_repr, bytes):
+            return oid_repr(oid_or_repr)
+        return oid_or_repr
+
+    # Do not use cache decorators, let ZODB do its caching.
+    def get_obj(self, oid):
+        u"""Get the object from its `oid'."""
+        oid = self.oid_or_repr_to_oid(oid)
+        obj = self.connection.get(oid)
+        obj._p_activate()
+        return obj
+
+    # @instance.memoize
+    def get_obj_as_str(self, oid):
+        try:
+            return str(self.get_obj(oid))
+        except Exception:
+            return '<error>'
+
+    # @instance.memoize
+    def get_physical_path(self, oid):
+        try:
+            return self.get_obj(oid).getPhysicalPath()
+        except Exception:
+            return None
+
+    # @instance.memoize
+    def get_id(self, oid):
+        obj = self.get_obj(oid)
+        if oid == self.root_oid:
+            return 'Root'
+        getId = getattr(obj, 'getId', None)
+        if getId:
+            try:
+                return getId()
+            except:  # noqa
+                pass
+        return getattr(obj, 'id', None)
+
+    # @instance.memoize
+    def get_attr_name(self, oid, parent_oid):
+        oid = self.oid_or_repr_to_oid(oid)
+        obj = self.get_obj(oid)
+        parent = self.get_obj(parent_oid)
+        names_and_values = ((name, getattr(parent, name, None)) for name in dir(parent))
+        return next((name for (name, value) in names_and_values if value is obj), None)
+
+    # @instance.memoize
+    def get_id_or_attr_name(self, oid, parent_oid=None):
+        identifier = self.get_id(oid)
+        if identifier:
+            return identifier
+
+        return self.get_attr_name(oid, parent_oid) if parent_oid else None
+
+    def load_reference_tree(self):
+        path = self._get_reference_cache_path()
+        if os.path.exists(path):
+            with open(path, 'r') as f:
+                logger.info('Loading json reference-cache from {}'.format(path))
+                self.refs = json.load(f)
+        else:
+            self._build_ref_tree()
+            self._store_reference_cache()
+
+    def _store_reference_cache(self):
+        path = self._get_reference_cache_path()
+        dirname = os.path.dirname(path)
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+        with open(path, 'w') as f:
+            json.dump(self.refs, f)
+        logger.info('Save reference-cache as {}'.format(path))
+
+    def _get_reference_cache_path(self):
+        cache_dir = os.path.join(os.path.expanduser('~'), '.cache', 'zodbverify')
+        last_tid = tid_repr(self.storage.lastTransaction())
+        return os.path.join(cache_dir, 'zodb_references_{}.json'.format(last_tid))
 
 
 def verify_oid(storage, oid, debug=False, app=None):
@@ -77,14 +196,12 @@ def verify_oid(storage, oid, debug=False, app=None):
     try:
         # by default expect a 8-byte string (e.g. '0x22d17d')
         # transform to a 64-bit long integer (e.g. b'\x00\x00\x00\x00\x00"\xd1}')
-        as_int = int(oid, 0)
-        oid = p64(as_int)
-    except ValueError:
-        # probably already a 64-bit long integer
+        oid = repr_to_oid(oid)
+    except:
         pass
 
     if app:
-        # use exitsing zope instance.
+        # use existing zope instance.
         # only available when used as ./bin/instance zodbverify -o XXX
         connection = app._p_jar
     else:
@@ -116,7 +233,6 @@ def verify_oid(storage, oid, debug=False, app=None):
     if not success:
         logger.info('{}: {}'.format(msg, oid_repr(oid)))
 
-    refbuilder = Refbuilder(storage)
-    refbuilder.build_ref_tree()
-    logger.info('\nThis oid is referenced by:\n')
-    refbuilder.get_refs(oid)
+    refbuilder = Refbuilder(storage, connection)
+    refbuilder.load_reference_tree()
+    refbuilder.get_oid_report(oid_repr(oid), verbose=True)

--- a/src/zodbverify/verify_oid.py
+++ b/src/zodbverify/verify_oid.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+from collections import defaultdict
 from ZODB.interfaces import IStorageCurrentRecordIteration
+from ZODB.serialize import get_refs
+from ZODB.utils import get_pickle_metadata
 from ZODB.utils import oid_repr
 from ZODB.utils import p64
 from zodbverify.verify import verify_record
@@ -11,6 +14,58 @@ import ZODB
 
 
 logger = logging.getLogger("zodbverify")
+
+
+class Refbuilder(object):
+
+    def __init__(self, storage):
+        self.storage = storage
+        self.seen = []
+        self.refs = defaultdict(list)
+        self.stop_recurse = [
+            p64(0x00),  # persistent.mapping.PersistentMapping
+            p64(0x01),  # OFS.Application.Application
+            p64(0x11),  # Products.CMFPlone.Portal.PloneSite
+        ]
+
+    def build_ref_tree(self):
+        logger.info('Building a reference-tree of ZODB...')
+        count = 0
+        next_ = None
+        while True:
+            count += 1
+            oid, tid, data, next_ = self.storage.record_iternext(next_)
+
+            # For each oid create a list of oids that reference it
+            # Can be used for reverse lookup similar to what fsoids.py
+            # in ZODB does.
+            # We store integers since that uses less memory.
+            oid_refs = get_refs(data)
+            if oid_refs:
+                for referenced_oid, class_info in oid_refs:
+                    self.refs[referenced_oid].append(oid)
+            if next_ is None:
+                break
+            if not count % 5000:
+                logger.info('Objects: {}'.format(count))
+        logger.info('Created a reference-dict for {} objects.\n'.format(count))
+
+    def get_refs(self, oid, level=0, max_level=10):
+        for ref in self.refs[oid]:
+            if ref in self.seen:
+                continue
+            level += 1
+            if level > max_level:
+                logger.info(' 8< --------------- >8 Stop after level {}!\n'.format(max_level))
+                continue
+            self.seen.append(ref)
+            pick, state = self.storage.load(ref)
+            class_info = '%s.%s' % get_pickle_metadata(pick)
+            logger.info('{} {} at level {}'.format(oid_repr(ref), class_info, level))
+            if oid in self.stop_recurse:
+                logger.info(' 8< --------------- >8 Stop at root objects\n')
+                continue
+            self.get_refs(ref, level)
 
 
 def verify_oid(storage, oid, debug=False, app=None):
@@ -60,3 +115,8 @@ def verify_oid(storage, oid, debug=False, app=None):
     success, msg = verify_record(oid, pickle, debug)
     if not success:
         logger.info('{}: {}'.format(msg, oid_repr(oid)))
+
+    refbuilder = Refbuilder(storage)
+    refbuilder.build_ref_tree()
+    logger.info('\nThis oid is referenced by:\n')
+    refbuilder.get_refs(oid)


### PR DESCRIPTION
First I build a dict of all references for reverse-lookup. 
Then I recursively follow the trail of references to referencing items up to the root.
To prevent irrelevant entries I abort after level 10 and at some root-objects because these are usually references a lot and would clutter the result with irrelevant information.

The output should give a pretty good idea where in the object-tree a item is actually located, how to access and fix it.

Currently the output is like this:

```
$ ./bin/zodbverify -f var/filestorage/Data.fs -o 0x3384dc

INFO:zodbverify:Building a reference-tree of ZODB...
INFO:zodbverify:Objects: 5000
[...]
INFO:zodbverify:Objects: 120000
INFO:zodbverify:Created a reference-dict for 121106 objects.

INFO:zodbverify:
This oid is referenced by:

INFO:zodbverify:0x11c284 BTrees.OOBTree.OOBTree at level 1
INFO:zodbverify:0x11c278 z3c.relationfield.index.RelationCatalog at level 2
INFO:zodbverify:0x1e five.localsitemanager.registry.PersistentComponents at level 3
INFO:zodbverify:0x11 Products.CMFPlone.Portal.PloneSite at level 4
INFO:zodbverify:0x01 OFS.Application.Application at level 5
INFO:zodbverify: 8< --------------- >8 Stop at root objects

INFO:zodbverify:0x02f6 persistent.mapping.PersistentMapping at level 6
INFO:zodbverify: 8< --------------- >8 Stop at root objects

INFO:zodbverify:0x02f7 zope.component.persistentregistry.PersistentAdapterRegistry at level 7
INFO:zodbverify: 8< --------------- >8 Stop at root objects

INFO:zodbverify:0x02f5 plone.app.redirector.storage.RedirectionStorage at level 5
INFO:zodbverify:0x02fa zope.ramcache.ram.RAMCache at level 6
INFO:zodbverify:0x02fd plone.contentrules.engine.storage.RuleStorage at level 7
INFO:zodbverify:0x338f13 plone.app.contentrules.rule.Rule at level 8
INFO:zodbverify:0x0303 BTrees.OOBTree.OOBTree at level 9
INFO:zodbverify:0x346961 plone.app.contentrules.rule.Rule at level 9
INFO:zodbverify:0x346b59 plone.app.contentrules.rule.Rule at level 10
INFO:zodbverify: 8< --------------- >8 Stop after level 10!

INFO:zodbverify:0x02fe plone.app.viewletmanager.storage.ViewletSettingsStorage at level 8
INFO:zodbverify:0x034d plone.keyring.keyring.Keyring at level 9
INFO:zodbverify:0x02fb persistent.mapping.PersistentMapping at level 10
INFO:zodbverify: 8< --------------- >8 Stop after level 10!

INFO:zodbverify: 8< --------------- >8 Stop after level 10!

INFO:zodbverify:0x3b1a32 plone.keyring.keyring.Keyring at level 10
INFO:zodbverify: 8< --------------- >8 Stop after level 10!

INFO:zodbverify: 8< --------------- >8 Stop after level 10!

INFO:zodbverify:0x3c1ab3 BTrees.OOBTree.OOBucket at level 2
INFO:zodbverify:0x3c2df1 BTrees.OOBTree.OOBucket at level 3
INFO:zodbverify:0x3c2d38 BTrees.OOBTree.OOBucket at level 4
INFO:zodbverify:0x3c23e0 BTrees.OOBTree.OOBucket at level 5
INFO:zodbverify:0x3c1e2c BTrees.OOBTree.OOBucket at level 6
INFO:zodbverify:0x3c1aaa BTrees.OOBTree.OOBucket at level 7
INFO:zodbverify:0x3eb91c BTrees.OOBTree.OOBucket at level 8
INFO:zodbverify:0x3ec134 BTrees.OOBTree.OOBucket at level 9
INFO:zodbverify:0x3ebeca BTrees.OOBTree.OOBucket at level 10
INFO:zodbverify: 8< --------------- >8 Stop after level 10!
```

This will show that the object in question exists in the Relation-Catalog and can be accessed, and also deleted using the api of this tool.

I'd like some feedback on how to improve this further.